### PR TITLE
Add Qt 5 compatibility

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -368,6 +368,44 @@ jobs:
           dist/mcp-bridge-*.zip
         if-no-files-found: ignore
 
+  build-qt5:
+    name: Ubuntu 22.04 GCC (Qt 5.15.2)
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+    - name: Download Ninja and CMake
+      uses: lukka/get-cmake@2ecc21724e5215b0e567bc399a2602d2ecb48541
+      with:
+        cmakeVersion: ${{ env.CMAKE_VERSION }}
+        ninjaVersion: ${{ env.NINJA_VERSION }}
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
+      with:
+        version: '5.15.2'
+        cache: 'true'
+
+    - name: Install xvfb
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends xvfb
+
+    - name: Configure
+      run: >
+        cmake -S . -B build -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        "-DCMAKE_PREFIX_PATH=$QT_ROOT_DIR"
+        -DLLMQORE_BUILD_TESTS=ON
+        -DLLMQORE_BUILD_EXAMPLES=OFF
+        -DLLMQORE_BUILD_MCP_BRIDGE=ON
+
+    - name: Build
+      run: cmake --build build
+
+    - name: Run unit tests
+      run: xvfb-run ./build/tests/LLMQoreUnitTests
+
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/v')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ if(NOT DEFINED QT_VERSION_MAJOR)
 endif()
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Concurrent)
 
+if(QT_VERSION_MAJOR EQUAL 5)
+    set(LLMQORE_CXX_STANDARD 17)
+else()
+    set(LLMQORE_CXX_STANDARD 20)
+endif()
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/LLMQore/Version.hpp.in
     ${CMAKE_CURRENT_BINARY_DIR}/include/LLMQore/Version.hpp
@@ -23,7 +29,7 @@ add_library(LLMQore::LLMQore ALIAS LLMQore)
 
 set_target_properties(LLMQore PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD 20
+    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     POSITION_INDEPENDENT_CODE ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,6 @@ if(NOT DEFINED QT_VERSION_MAJOR)
 endif()
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Concurrent)
 
-if(QT_VERSION_MAJOR EQUAL 5)
-    set(LLMQORE_CXX_STANDARD 17)
-else()
-    set(LLMQORE_CXX_STANDARD 20)
-endif()
-
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/LLMQore/Version.hpp.in
     ${CMAKE_CURRENT_BINARY_DIR}/include/LLMQore/Version.hpp
@@ -29,7 +23,7 @@ add_library(LLMQore::LLMQore ALIAS LLMQore)
 
 set_target_properties(LLMQore PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     POSITION_INDEPENDENT_CODE ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,10 @@ project(LLMQore
     DESCRIPTION "Qt/C++ library for LLM provider integration"
 )
 
-find_package(Qt6 REQUIRED COMPONENTS Core Network Concurrent)
+if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core Network Concurrent)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Concurrent)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/include/LLMQore/Version.hpp.in
@@ -41,10 +44,10 @@ target_include_directories(LLMQore
 
 target_link_libraries(LLMQore
     PUBLIC
-        Qt6::Core
-        Qt6::Network
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Network
     PRIVATE
-        Qt6::Concurrent
+        Qt${QT_VERSION_MAJOR}::Concurrent
 )
 
 target_compile_definitions(LLMQore PRIVATE LLMQORE_LIBRARY)
@@ -76,6 +79,14 @@ if(LLMQORE_INSTALL)
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         PATTERN "*.in" EXCLUDE
     )
+
+    if(QT_VERSION_MAJOR EQUAL 5)
+        install(FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/QPromise
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/QByteArrayView
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
+    endif()
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/LLMQore/Version.hpp
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/LLMQore

--- a/cmake/LLMQoreConfig.cmake.in
+++ b/cmake/LLMQoreConfig.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Qt6 COMPONENTS Core Network)
+find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS Core Network)
 
 include("${CMAKE_CURRENT_LIST_DIR}/LLMQoreTargets.cmake")
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_CXX_STANDARD ${LLMQORE_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(QT_KNOWN_POLICY_QTP0001)
@@ -78,10 +78,13 @@ add_executable(example-mcp-server
 )
 set_target_properties(example-mcp-server PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )
+if(QT_VERSION_MAJOR EQUAL 5)
+    set_property(TARGET example-mcp-server PROPERTY CXX_STANDARD 17)
+endif()
 target_link_libraries(example-mcp-server
     PRIVATE
     LLMQore::LLMQore
@@ -109,7 +112,7 @@ add_executable(example-mcp-http-probe
 )
 set_target_properties(example-mcp-http-probe PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD ${LLMQORE_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(QT_KNOWN_POLICY_QTP0001)
@@ -78,7 +78,7 @@ add_executable(example-mcp-server
 )
 set_target_properties(example-mcp-server PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD 20
+    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )
@@ -109,7 +109,7 @@ add_executable(example-mcp-http-probe
 )
 set_target_properties(example-mcp-http-probe PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD 20
+    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,77 +8,87 @@ if(QT_KNOWN_POLICY_QTP0001)
     qt_policy(SET QTP0001 NEW)
 endif()
 
-find_package(Qt6 REQUIRED COMPONENTS Core Network Concurrent Quick)
+if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core Network Concurrent Quick)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Concurrent Quick)
 
 # Locate windeployqt next to qmake so we can drop all needed Qt runtime
 # (platform plugin, QML modules, DLLs) next to the example binaries on
 # Windows. Makes them standalone and launchable from Qt Creator, Explorer,
 # or any shell regardless of PATH / plugin env.
 if(WIN32)
-    get_target_property(_qt_qmake_exe Qt6::qmake IMPORTED_LOCATION)
+    get_target_property(_qt_qmake_exe Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
     get_filename_component(_qt_bin_dir "${_qt_qmake_exe}" DIRECTORY)
     set(_windeployqt "${_qt_bin_dir}/windeployqt.exe")
 endif()
 
-qt_add_executable(example-chat
-    main.cpp
-    MessageModel.hpp
-    ChatController.hpp
-    ChatController.cpp
-    ExampleTools.hpp
-)
-
-qt_add_qml_module(example-chat
-    URI example.LLMQoreChat
-    VERSION 1.0
-    QML_FILES
-        Main.qml
-        qml/ChatBubble.qml
-        qml/ChatInput.qml
-        qml/ProviderBar.qml
-        qml/ToolBadge.qml
-        qml/ToolsDrawer.qml
-)
-
-target_link_libraries(example-chat
-    PRIVATE
-    LLMQore::LLMQore
-    Qt6::Core
-    Qt6::Network
-    Qt6::Concurrent
-    Qt6::Quick
-)
-
-# On Windows, run windeployqt so the example-chat binary ships with its
-# platform plugin, QML modules, and Qt DLLs. Without this the exe cannot
-# start when launched outside a Qt-aware shell environment.
-if(WIN32 AND EXISTS "${_windeployqt}")
-    add_custom_command(
-        TARGET example-chat POST_BUILD
-        COMMAND "${_windeployqt}"
-            --no-translations
-            --no-system-d3d-compiler
-            --no-opengl-sw
-            --qmldir "${CMAKE_CURRENT_SOURCE_DIR}"
-            "$<TARGET_FILE:example-chat>"
-        COMMENT "Deploying Qt runtime next to example-chat.exe"
-        VERBATIM
+if(QT_VERSION_MAJOR GREATER_EQUAL 6)
+    qt_add_executable(example-chat
+        main.cpp
+        MessageModel.hpp
+        ChatController.hpp
+        ChatController.cpp
+        ExampleTools.hpp
     )
+
+    qt_add_qml_module(example-chat
+        URI example.LLMQoreChat
+        VERSION 1.0
+        QML_FILES
+            Main.qml
+            qml/ChatBubble.qml
+            qml/ChatInput.qml
+            qml/ProviderBar.qml
+            qml/ToolBadge.qml
+            qml/ToolsDrawer.qml
+    )
+
+    target_link_libraries(example-chat
+        PRIVATE
+        LLMQore::LLMQore
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Network
+        Qt${QT_VERSION_MAJOR}::Concurrent
+        Qt${QT_VERSION_MAJOR}::Quick
+    )
+
+    # On Windows, run windeployqt so the example-chat binary ships with its
+    # platform plugin, QML modules, and Qt DLLs. Without this the exe cannot
+    # start when launched outside a Qt-aware shell environment.
+    if(WIN32 AND EXISTS "${_windeployqt}")
+        add_custom_command(
+            TARGET example-chat POST_BUILD
+            COMMAND "${_windeployqt}"
+                --no-translations
+                --no-system-d3d-compiler
+                --no-opengl-sw
+                --qmldir "${CMAKE_CURRENT_SOURCE_DIR}"
+                "$<TARGET_FILE:example-chat>"
+            COMMENT "Deploying Qt runtime next to example-chat.exe"
+            VERBATIM
+        )
+    endif()
 endif()
 
 # MCP server demo: publish local BaseTools over stdio, launchable from Claude Desktop.
-qt_add_executable(example-mcp-server
+add_executable(example-mcp-server
     mcp-server-demo/main.cpp
     ExampleTools.hpp
+)
+set_target_properties(example-mcp-server PROPERTIES
+    AUTOMOC ON
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
 )
 target_link_libraries(example-mcp-server
     PRIVATE
     LLMQore::LLMQore
-    Qt6::Core
-    Qt6::Network
-    Qt6::Concurrent
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Concurrent
 )
-set_target_properties(example-mcp-server PROPERTIES AUTOMOC ON)
 
 if(WIN32 AND EXISTS "${_windeployqt}")
     add_custom_command(
@@ -94,16 +104,21 @@ if(WIN32 AND EXISTS "${_windeployqt}")
 endif()
 
 # Smoke-test utility for McpHttpTransport (both legacy and streamable paths).
-qt_add_executable(example-mcp-http-probe
+add_executable(example-mcp-http-probe
     mcp-http-probe/main.cpp
+)
+set_target_properties(example-mcp-http-probe PROPERTIES
+    AUTOMOC ON
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
 )
 target_link_libraries(example-mcp-http-probe
     PRIVATE
     LLMQore::LLMQore
-    Qt6::Core
-    Qt6::Network
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Network
 )
-set_target_properties(example-mcp-http-probe PROPERTIES AUTOMOC ON)
 
 if(WIN32 AND EXISTS "${_windeployqt}")
     add_custom_command(

--- a/include/LLMQore/FutureUtils.hpp
+++ b/include/LLMQore/FutureUtils.hpp
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Martin Siggel
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include <memory>

--- a/include/LLMQore/FutureUtils.hpp
+++ b/include/LLMQore/FutureUtils.hpp
@@ -1,0 +1,310 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <QFuture>
+#include <QFutureWatcher>
+#include <QObject>
+
+#include <QPromise>
+
+#include <LLMQore/HttpTransportError.hpp>
+#include <LLMQore/McpExceptions.hpp>
+
+namespace LLMQore {
+
+template<typename T, typename F>
+auto futureThen(QObject *context, const QFuture<T> &future, F &&fn)
+    -> QFuture<std::decay_t<std::invoke_result_t<F, const T &>>>;
+
+template<typename F>
+auto futureThen(QObject *context, const QFuture<void> &future, F &&fn)
+    -> QFuture<std::decay_t<std::invoke_result_t<F>>>;
+
+template<typename T, typename F>
+QFuture<T> futureOnFailed(QObject *context, const QFuture<T> &future, F &&fn);
+
+namespace detail {
+
+template<typename T>
+struct FutureValue;
+
+template<typename T>
+struct IsQFuture : std::false_type {};
+
+template<typename T>
+struct FutureValue<QFuture<T>>
+{
+    using type = T;
+};
+
+template<typename T>
+struct IsQFuture<QFuture<T>> : std::true_type {};
+
+template<typename T>
+T futureResultOrRethrow(const QFuture<T> &future)
+{
+    return future.result();
+}
+
+inline void futureResultOrRethrow(QFuture<void> future)
+{
+    future.waitForFinished();
+}
+
+template<typename T>
+QFuture<T> futureUnwrap(const QFuture<QFuture<T>> &future)
+{
+    auto promise = std::make_shared<QPromise<T>>();
+    promise->start();
+
+    auto *watcher = new QFutureWatcher<QFuture<T>>();
+    QObject::connect(watcher, &QFutureWatcher<QFuture<T>>::finished, watcher,
+                     [watcher, promise]() mutable {
+                         try {
+                             const QFuture<T> inner = futureResultOrRethrow(watcher->future());
+                             auto *innerWatcher = new QFutureWatcher<T>();
+                             QObject::connect(innerWatcher, &QFutureWatcher<T>::finished, innerWatcher,
+                                              [innerWatcher, promise]() mutable {
+                                                  try {
+                                                      if constexpr (std::is_void_v<T>) {
+                                                          futureResultOrRethrow(innerWatcher->future());
+                                                          promise->finish();
+                                                      } else {
+                                                          promise->addResult(
+                                                              futureResultOrRethrow(innerWatcher->future()));
+                                                          promise->finish();
+                                                      }
+                                                  } catch (...) {
+                                                      promise->setException(std::current_exception());
+                                                      promise->finish();
+                                                  }
+                                                  innerWatcher->deleteLater();
+                                              });
+                             innerWatcher->setFuture(inner);
+                         } catch (...) {
+                             promise->setException(std::current_exception());
+                             promise->finish();
+                         }
+                         watcher->deleteLater();
+                     });
+    watcher->setFuture(future);
+    return promise->future();
+}
+
+template<typename F, typename E, typename T>
+bool invokeFailureHandler(
+    const std::shared_ptr<QPromise<T>> &promise,
+    F &&fn,
+    const E &error)
+{
+    if constexpr (std::is_invocable_v<F, const E &>) {
+        try {
+            using Result = std::invoke_result_t<F, const E &>;
+            if constexpr (std::is_void_v<Result>) {
+                std::forward<F>(fn)(error);
+            } else {
+                if constexpr (std::is_void_v<T>)
+                    std::forward<F>(fn)(error);
+                else
+                    promise->addResult(std::forward<F>(fn)(error));
+            }
+            promise->finish();
+        } catch (...) {
+            promise->setException(std::current_exception());
+            promise->finish();
+        }
+        return true;
+    }
+    return false;
+}
+
+template<typename F, typename T>
+void resolveFailure(
+    const std::shared_ptr<QPromise<T>> &promise,
+    F &&fn,
+    std::exception_ptr exception)
+{
+    try {
+        std::rethrow_exception(exception);
+    } catch (const HttpTransportError &e) {
+        if (invokeFailureHandler(promise, fn, e))
+            return;
+    } catch (const Mcp::McpException &e) {
+        if (invokeFailureHandler(promise, fn, e))
+            return;
+    } catch (const std::exception &e) {
+        if (invokeFailureHandler(promise, fn, e))
+            return;
+    }
+
+    promise->setException(exception);
+    promise->finish();
+}
+
+template<typename T>
+class FutureCompat
+{
+public:
+    explicit FutureCompat(QFuture<T> future)
+        : m_future(std::move(future))
+    {}
+
+    template<typename F>
+    auto then(QObject *context, F &&fn) const
+        -> FutureCompat<std::decay_t<std::invoke_result_t<F, const T &>>>
+    {
+        return FutureCompat<std::decay_t<std::invoke_result_t<F, const T &>>>(
+            LLMQore::futureThen(context, m_future, std::forward<F>(fn)));
+    }
+
+    template<typename F>
+    FutureCompat<T> onFailed(QObject *context, F &&fn) const
+    {
+        return FutureCompat<T>(LLMQore::futureOnFailed(context, m_future, std::forward<F>(fn)));
+    }
+
+    template<typename U = T, std::enable_if_t<IsQFuture<U>::value, int> = 0>
+    auto unwrap() const -> FutureCompat<typename FutureValue<U>::type>
+    {
+        using Inner = typename FutureValue<U>::type;
+        return FutureCompat<Inner>(LLMQore::detail::futureUnwrap(m_future));
+    }
+
+    operator QFuture<T>() const
+    {
+        return m_future;
+    }
+
+private:
+    QFuture<T> m_future;
+};
+
+template<>
+class FutureCompat<void>
+{
+public:
+    explicit FutureCompat(QFuture<void> future)
+        : m_future(std::move(future))
+    {}
+
+    template<typename F>
+    auto then(QObject *context, F &&fn) const
+        -> FutureCompat<std::decay_t<std::invoke_result_t<F>>>
+    {
+        return FutureCompat<std::decay_t<std::invoke_result_t<F>>>(
+            LLMQore::futureThen(context, m_future, std::forward<F>(fn)));
+    }
+
+    template<typename F>
+    FutureCompat<void> onFailed(QObject *context, F &&fn) const
+    {
+        return FutureCompat<void>(LLMQore::futureOnFailed(context, m_future, std::forward<F>(fn)));
+    }
+
+    operator QFuture<void>() const
+    {
+        return m_future;
+    }
+
+private:
+    QFuture<void> m_future;
+};
+
+} // namespace detail
+
+template<typename T, typename F>
+auto futureThen(QObject *context, const QFuture<T> &future, F &&fn)
+    -> QFuture<std::decay_t<std::invoke_result_t<F, const T &>>>
+{
+    using Result = std::decay_t<std::invoke_result_t<F, const T &>>;
+    auto promise = std::make_shared<QPromise<Result>>();
+    promise->start();
+
+    auto *watcher = new QFutureWatcher<T>(context);
+    QObject::connect(watcher, &QFutureWatcher<T>::finished, watcher,
+                     [watcher, promise, fn = std::forward<F>(fn)]() mutable {
+                         try {
+                             if constexpr (std::is_void_v<Result>) {
+                                 fn(detail::futureResultOrRethrow(watcher->future()));
+                                 promise->finish();
+                             } else {
+                                 promise->addResult(
+                                     fn(detail::futureResultOrRethrow(watcher->future())));
+                                 promise->finish();
+                             }
+                         } catch (...) {
+                             promise->setException(std::current_exception());
+                             promise->finish();
+                         }
+                         watcher->deleteLater();
+                     });
+    watcher->setFuture(future);
+    return promise->future();
+}
+
+template<typename F>
+auto futureThen(QObject *context, const QFuture<void> &future, F &&fn)
+    -> QFuture<std::decay_t<std::invoke_result_t<F>>>
+{
+    using Result = std::decay_t<std::invoke_result_t<F>>;
+    auto promise = std::make_shared<QPromise<Result>>();
+    promise->start();
+
+    auto *watcher = new QFutureWatcher<void>(context);
+    QObject::connect(watcher, &QFutureWatcher<void>::finished, watcher,
+                     [watcher, promise, fn = std::forward<F>(fn)]() mutable {
+                         try {
+                             detail::futureResultOrRethrow(watcher->future());
+                             if constexpr (std::is_void_v<Result>) {
+                                 fn();
+                                 promise->finish();
+                             } else {
+                                 promise->addResult(fn());
+                                 promise->finish();
+                             }
+                         } catch (...) {
+                             promise->setException(std::current_exception());
+                             promise->finish();
+                         }
+                         watcher->deleteLater();
+                     });
+    watcher->setFuture(future);
+    return promise->future();
+}
+
+template<typename T, typename F>
+QFuture<T> futureOnFailed(QObject *context, const QFuture<T> &future, F &&fn)
+{
+    auto promise = std::make_shared<QPromise<T>>();
+    promise->start();
+
+    auto *watcher = new QFutureWatcher<T>(context);
+    QObject::connect(watcher, &QFutureWatcher<T>::finished, watcher,
+                     [watcher, promise, fn = std::forward<F>(fn)]() mutable {
+                         try {
+                             if constexpr (std::is_void_v<T>) {
+                                 detail::futureResultOrRethrow(watcher->future());
+                                 promise->finish();
+                             } else {
+                                 promise->addResult(detail::futureResultOrRethrow(watcher->future()));
+                                 promise->finish();
+                             }
+                         } catch (...) {
+                             detail::resolveFailure(promise, fn, std::current_exception());
+                         }
+                         watcher->deleteLater();
+                     });
+    watcher->setFuture(future);
+    return promise->future();
+}
+
+template<typename T>
+detail::FutureCompat<std::decay_t<T>> compat(QFuture<T> future)
+{
+    return detail::FutureCompat<std::decay_t<T>>(std::move(future));
+}
+
+} // namespace LLMQore

--- a/include/QByteArrayView
+++ b/include/QByteArrayView
@@ -1,0 +1,52 @@
+#pragma once
+
+#if QT_VERSION_MAJOR >= 6
+
+#include <QtCore/QByteArrayView>
+
+#else
+
+#include <QByteArray>
+#include <QtGlobal>
+
+class QByteArrayView
+{
+public:
+    QByteArrayView() = default;
+    QByteArrayView(const char *data)
+        : m_data(data)
+    {}
+    QByteArrayView(const QByteArray &data)
+        : m_data(data)
+    {}
+    QByteArrayView(QByteArray &&data)
+        : m_data(std::move(data))
+    {}
+
+    [[nodiscard]] QByteArray toByteArray() const { return m_data; }
+    [[nodiscard]] bool isEmpty() const noexcept { return m_data.isEmpty(); }
+    [[nodiscard]] int size() const noexcept { return m_data.size(); }
+    [[nodiscard]] const char *data() const noexcept { return m_data.constData(); }
+
+    [[nodiscard]] int compare(const QByteArrayView &other, Qt::CaseSensitivity cs = Qt::CaseSensitive) const
+    {
+        return m_data.compare(other.m_data, cs);
+    }
+
+    [[nodiscard]] int compare(const QByteArray &other, Qt::CaseSensitivity cs = Qt::CaseSensitive) const
+    {
+        return m_data.compare(other, cs);
+    }
+
+    [[nodiscard]] int compare(const char *other, Qt::CaseSensitivity cs = Qt::CaseSensitive) const
+    {
+        return m_data.compare(QByteArray(other), cs);
+    }
+
+    operator QByteArray() const { return m_data; }
+
+private:
+    QByteArray m_data;
+};
+
+#endif

--- a/include/QByteArrayView
+++ b/include/QByteArrayView
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Martin Siggel
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #if QT_VERSION_MAJOR >= 6

--- a/include/QPromise
+++ b/include/QPromise
@@ -1,0 +1,103 @@
+#pragma once
+
+#if QT_VERSION_MAJOR >= 6
+
+#include <QtCore/QPromise>
+
+#else
+
+#include <exception>
+#include <memory>
+
+#include <QException>
+#include <QFuture>
+#include <QFutureInterface>
+#include <QString>
+
+class QStdExceptionWrapper : public QException
+{
+public:
+    QStdExceptionWrapper() = default;
+    explicit QStdExceptionWrapper(QString message)
+        : m_message(std::move(message))
+        , m_stdMessage(m_message.toStdString())
+    {}
+
+    void raise() const override { throw *this; }
+    QStdExceptionWrapper *clone() const override { return new QStdExceptionWrapper(*this); }
+    const char *what() const noexcept override { return m_stdMessage.c_str(); }
+
+private:
+    QString m_message;
+    std::string m_stdMessage;
+};
+
+template<typename T>
+class QPromise
+{
+public:
+    QPromise() = default;
+    QPromise(const QPromise &) = delete;
+    QPromise &operator=(const QPromise &) = delete;
+
+    void start() { m_interface.reportStarted(); }
+    void finish() { m_interface.reportFinished(); }
+
+    void addResult(const T &result) { m_interface.reportResult(result); }
+    void addResult(T &&result) { m_interface.reportResult(std::move(result)); }
+
+    void setException(std::exception_ptr exception)
+    {
+        if (!exception)
+            return;
+        try {
+            std::rethrow_exception(exception);
+        } catch (const QException &e) {
+            m_interface.reportException(e);
+        } catch (const std::exception &e) {
+            m_interface.reportException(QStdExceptionWrapper(QString::fromUtf8(e.what())));
+        } catch (...) {
+            m_interface.reportException(QStdExceptionWrapper(QStringLiteral("unknown exception")));
+        }
+    }
+
+    QFuture<T> future() { return m_interface.future(); }
+
+private:
+    QFutureInterface<T> m_interface;
+};
+
+template<>
+class QPromise<void>
+{
+public:
+    QPromise() = default;
+    QPromise(const QPromise &) = delete;
+    QPromise &operator=(const QPromise &) = delete;
+
+    void start() { m_interface.reportStarted(); }
+    void finish() { m_interface.reportFinished(); }
+    void addResult() {}
+
+    void setException(std::exception_ptr exception)
+    {
+        if (!exception)
+            return;
+        try {
+            std::rethrow_exception(exception);
+        } catch (const QException &e) {
+            m_interface.reportException(e);
+        } catch (const std::exception &e) {
+            m_interface.reportException(QStdExceptionWrapper(QString::fromUtf8(e.what())));
+        } catch (...) {
+            m_interface.reportException(QStdExceptionWrapper(QStringLiteral("unknown exception")));
+        }
+    }
+
+    QFuture<void> future() { return m_interface.future(); }
+
+private:
+    QFutureInterface<void> m_interface;
+};
+
+#endif

--- a/include/QPromise
+++ b/include/QPromise
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Martin Siggel
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #if QT_VERSION_MAJOR >= 6

--- a/mcp-bridge/BridgeServer.cpp
+++ b/mcp-bridge/BridgeServer.cpp
@@ -6,6 +6,8 @@
 #include <QCoreApplication>
 #include <QTimer>
 
+#include <LLMQore/FutureUtils.hpp>
+
 using namespace LLMQore::Mcp;
 
 namespace {
@@ -120,7 +122,7 @@ void BridgeServer::connectUpstream(int index)
 
     qInfo().noquote() << QString("Connecting to [%1]...").arg(name);
 
-    upstream.client->connectAndInitialize(std::chrono::seconds(30))
+    LLMQore::compat(upstream.client->connectAndInitialize(std::chrono::seconds(30)))
         .then(this,
               [this, index, name](const InitializeResult &result) {
                   qInfo().noquote() << QString("[%1] connected — %2 %3")
@@ -191,7 +193,7 @@ void BridgeServer::reconnectUpstream(int index)
     const QString name = upstream.name;
     qInfo().noquote() << QString("[%1] reconnecting...").arg(name);
 
-    upstream.client->connectAndInitialize(std::chrono::seconds(30))
+    LLMQore::compat(upstream.client->connectAndInitialize(std::chrono::seconds(30)))
         .then(this,
               [this, index, name](const InitializeResult &result) {
                   qInfo().noquote() << QString("[%1] reconnected — %2 %3")
@@ -239,7 +241,7 @@ void BridgeServer::resyncTools(int index)
 
     clearTools(index);
 
-    upstream.client->listTools().then(this, [this, index, name](const QList<ToolInfo> &tools) {
+    LLMQore::compat(upstream.client->listTools()).then(this, [this, index, name](const QList<ToolInfo> &tools) {
         registerTools(index, tools);
         qInfo().noquote() << QString("[%1] re-synced: %2 tools.").arg(name).arg(tools.size());
     });

--- a/mcp-bridge/CMakeLists.txt
+++ b/mcp-bridge/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(mcp-bridge
 
 set_target_properties(mcp-bridge PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )

--- a/mcp-bridge/CMakeLists.txt
+++ b/mcp-bridge/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(mcp-bridge
 
 set_target_properties(mcp-bridge PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD 20
+    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )

--- a/mcp-bridge/CMakeLists.txt
+++ b/mcp-bridge/CMakeLists.txt
@@ -1,4 +1,9 @@
-qt_add_executable(mcp-bridge
+if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core Network Concurrent)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Concurrent)
+
+add_executable(mcp-bridge
     main.cpp
     BridgeConfig.hpp
     BridgeConfig.cpp
@@ -6,15 +11,20 @@ qt_add_executable(mcp-bridge
     BridgeServer.cpp
 )
 
+set_target_properties(mcp-bridge PROPERTIES
+    AUTOMOC ON
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+
 target_link_libraries(mcp-bridge
     PRIVATE
     LLMQore::LLMQore
-    Qt6::Core
-    Qt6::Network
-    Qt6::Concurrent
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Concurrent
 )
-
-set_target_properties(mcp-bridge PROPERTIES AUTOMOC ON)
 
 if(APPLE)
     set_target_properties(mcp-bridge PROPERTIES
@@ -48,7 +58,9 @@ install(FILES mcp-bridge.json
 )
 
 if(WIN32)
-    set(_windeployqt "${QT6_INSTALL_PREFIX}/${QT6_INSTALL_BINS}/windeployqt.exe")
+    get_target_property(_qt_qmake_exe Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+    get_filename_component(_qt_bin_dir "${_qt_qmake_exe}" DIRECTORY)
+    set(_windeployqt "${_qt_bin_dir}/windeployqt.exe")
     install(CODE "
         execute_process(
             COMMAND \"${_windeployqt}\"
@@ -61,7 +73,9 @@ if(WIN32)
         )
     " COMPONENT mcp-bridge)
 elseif(APPLE)
-    set(_macdeployqt "${QT6_INSTALL_PREFIX}/${QT6_INSTALL_BINS}/macdeployqt")
+    get_target_property(_qt_qmake_exe Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+    get_filename_component(_qt_bin_dir "${_qt_qmake_exe}" DIRECTORY)
+    set(_macdeployqt "${_qt_bin_dir}/macdeployqt")
     install(CODE "
         message(STATUS \"Running macdeployqt on \${CMAKE_INSTALL_PREFIX}/mcp-bridge.app\")
         execute_process(
@@ -85,24 +99,29 @@ elseif(APPLE)
         endif()
     " COMPONENT mcp-bridge)
 else()
-    foreach(_lib Qt6Core Qt6Network Qt6Concurrent)
+    get_target_property(_qt_core_lib Qt${QT_VERSION_MAJOR}::Core IMPORTED_LOCATION)
+    get_filename_component(_qt_lib_dir "${_qt_core_lib}" DIRECTORY)
+
+    foreach(_lib Core Network Concurrent)
         file(GLOB _files
-            "${QT6_INSTALL_PREFIX}/${QT6_INSTALL_LIBS}/lib${_lib}.so*"
+            "${_qt_lib_dir}/libQt${QT_VERSION_MAJOR}${_lib}.so*"
         )
         install(FILES ${_files}
             DESTINATION lib
             COMPONENT mcp-bridge
         )
     endforeach()
-    foreach(_icu icui18n icuuc icudata)
-        file(GLOB _icu_files
-            "${QT6_INSTALL_PREFIX}/${QT6_INSTALL_LIBS}/lib${_icu}.so*"
-        )
-        if(_icu_files)
-            install(FILES ${_icu_files}
-                DESTINATION lib
-                COMPONENT mcp-bridge
+    if(QT_VERSION_MAJOR GREATER_EQUAL 6)
+        foreach(_icu icui18n icuuc icudata)
+            file(GLOB _icu_files
+                "${_qt_lib_dir}/lib${_icu}.so*"
             )
-        endif()
-    endforeach()
+            if(_icu_files)
+                install(FILES ${_icu_files}
+                    DESTINATION lib
+                    COMPONENT mcp-bridge
+                )
+            endif()
+        endforeach()
+    endif()
 endif()

--- a/source/clients/claude/ClaudeClient.cpp
+++ b/source/clients/claude/ClaudeClient.cpp
@@ -8,6 +8,7 @@
 #include <QUrlQuery>
 
 #include "ClaudeMessage.hpp"
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/HttpClient.hpp>
 #include <LLMQore/Log.hpp>
 #include <LLMQore/SSEParser.hpp>
@@ -82,8 +83,7 @@ QFuture<QList<QString>> ClaudeClient::listModels()
 
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             QList<QString> models;
             if (!response.isSuccess()) {

--- a/source/clients/google/GoogleAIClient.cpp
+++ b/source/clients/google/GoogleAIClient.cpp
@@ -8,6 +8,7 @@
 #include <QUrlQuery>
 
 #include "GoogleMessage.hpp"
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/HttpClient.hpp>
 #include <LLMQore/Log.hpp>
 #include <LLMQore/SSEParser.hpp>
@@ -75,8 +76,7 @@ QFuture<QList<QString>> GoogleAIClient::listModels()
     QUrl url(QString("%1/models").arg(m_url));
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             QList<QString> models;
             if (!response.isSuccess()) {

--- a/source/clients/llamacpp/LlamaCppClient.cpp
+++ b/source/clients/llamacpp/LlamaCppClient.cpp
@@ -7,6 +7,7 @@
 #include <QJsonDocument>
 
 #include "clients/openai/OpenAIMessage.hpp"
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/HttpClient.hpp>
 #include <LLMQore/Log.hpp>
 #include <LLMQore/SSEParser.hpp>
@@ -70,8 +71,7 @@ QFuture<QList<QString>> LlamaCppClient::listModels()
     QUrl url(m_url + "/v1/models");
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             QList<QString> models;
             if (!response.isSuccess()) {
@@ -102,8 +102,7 @@ QFuture<bool> LlamaCppClient::isServerReady()
     QUrl url(m_url + "/health");
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             if (!response.isSuccess())
                 return false;
@@ -118,8 +117,7 @@ QFuture<QJsonObject> LlamaCppClient::serverProps()
     QUrl url(m_url + "/props");
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) -> QJsonObject {
             if (!response.isSuccess())
                 return {};

--- a/source/clients/mistral/MistralClient.cpp
+++ b/source/clients/mistral/MistralClient.cpp
@@ -6,6 +6,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/HttpClient.hpp>
 #include <LLMQore/Log.hpp>
 
@@ -47,8 +48,7 @@ QFuture<QList<QString>> MistralClient::listModels()
     QUrl url(m_url + "/v1/models");
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             QList<QString> models;
             if (!response.isSuccess())

--- a/source/clients/ollama/OllamaClient.cpp
+++ b/source/clients/ollama/OllamaClient.cpp
@@ -7,6 +7,7 @@
 #include <QJsonDocument>
 
 #include "OllamaMessage.hpp"
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/HttpClient.hpp>
 #include <LLMQore/LineBuffer.hpp>
 #include <LLMQore/Log.hpp>
@@ -62,8 +63,7 @@ QFuture<QList<QString>> OllamaClient::listModels()
     QUrl url(m_url + "/api/tags");
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             QList<QString> models;
             if (!response.isSuccess()) {

--- a/source/clients/openai/OpenAIClient.cpp
+++ b/source/clients/openai/OpenAIClient.cpp
@@ -8,6 +8,7 @@
 #include <QJsonValue>
 
 #include "OpenAIMessage.hpp"
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/HttpClient.hpp>
 #include <LLMQore/Log.hpp>
 #include <LLMQore/SSEParser.hpp>
@@ -70,8 +71,7 @@ QFuture<QList<QString>> OpenAIClient::listModels()
     QUrl url(m_url + "/models");
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             QList<QString> models;
             if (!response.isSuccess()) {

--- a/source/clients/openai/OpenAIResponsesClient.cpp
+++ b/source/clients/openai/OpenAIResponsesClient.cpp
@@ -10,6 +10,7 @@
 #include <QJsonDocument>
 
 #include "OpenAIResponsesMessage.hpp"
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/Log.hpp>
 
 namespace LLMQore {
@@ -64,8 +65,7 @@ QFuture<QList<QString>> OpenAIResponsesClient::listModels()
     QUrl url(m_url + "/models");
     QNetworkRequest request = prepareNetworkRequest(url);
 
-    return httpClient()
-        ->send(request, QByteArrayView("GET"))
+    return LLMQore::compat(httpClient()->send(request, QByteArrayView("GET")))
         .then(this, [](const HttpResponse &response) {
             QList<QString> models;
             if (!response.isSuccess()) {

--- a/source/core/BaseClient.cpp
+++ b/source/core/BaseClient.cpp
@@ -8,6 +8,7 @@
 #include <QThread>
 #include <QUuid>
 
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/HttpClient.hpp>
 #include <LLMQore/HttpStream.hpp>
 #include <LLMQore/HttpTransportError.hpp>
@@ -182,7 +183,7 @@ void BaseClient::startHttpRequest(
     const QByteArray body = QJsonDocument(payload).toJson(QJsonDocument::Compact);
 
     if (mode == RequestMode::Buffered) {
-        m_httpClient->send(request, QByteArrayView("POST"), body)
+        (void)LLMQore::compat(m_httpClient->send(request, QByteArrayView("POST"), body))
             .then(this, [this, id](const HttpResponse &response) {
                 if (!hasRequest(id))
                     return;
@@ -196,12 +197,12 @@ void BaseClient::startHttpRequest(
                 processBufferedResponse(id, response.body);
                 onStreamFinished(id, std::nullopt);
             })
-            .onFailed(this, [this, id](const HttpTransportError &e) {
-                if (hasRequest(id))
+            .onFailed(this, [this, id](const auto &e) {
+                if (!hasRequest(id))
+                    return;
+                if constexpr (std::is_same_v<std::decay_t<decltype(e)>, HttpTransportError>)
                     onStreamFinished(id, e.message());
-            })
-            .onFailed(this, [this, id](const std::exception &e) {
-                if (hasRequest(id))
+                else
                     onStreamFinished(id, QString::fromUtf8(e.what()));
             });
         return;

--- a/source/mcp/McpClient.cpp
+++ b/source/mcp/McpClient.cpp
@@ -6,6 +6,7 @@
 #include <LLMQore/BaseClient.hpp>
 #include <LLMQore/BaseElicitationProvider.hpp>
 #include <LLMQore/BaseRootsProvider.hpp>
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/Log.hpp>
 #include <LLMQore/McpExceptions.hpp>
 #include <LLMQore/McpSession.hpp>
@@ -99,14 +100,13 @@ void McpClient::installHandlers()
             if (!m_rootsProvider)
                 return makeReadyJsonFuture(QJsonObject{{"roots", QJsonArray{}}});
 
-            return m_rootsProvider->listRoots()
-                .then(this,
-                      [](const QList<Root> &list) {
-                          QJsonArray arr;
-                          for (const Root &r : list)
-                              arr.append(r.toJson());
-                          return QJsonValue(QJsonObject{{"roots", arr}});
-                      })
+            return LLMQore::compat(m_rootsProvider->listRoots())
+                .then(this, [](const QList<Root> &list) {
+                    QJsonArray arr;
+                    for (const Root &r : list)
+                        arr.append(r.toJson());
+                    return QJsonValue(QJsonObject{{"roots", arr}});
+                })
                 .onFailed(this, [](const std::exception &) {
                     return QJsonValue(QJsonObject{{"roots", QJsonArray{}}});
                 });
@@ -222,18 +222,15 @@ void McpClient::installHandlers()
                     QStringLiteral("elicitation/create not supported"));
             }
             const ElicitRequestParams req = ElicitRequestParams::fromJson(params);
-            return m_elicitationProvider->elicit(req).then(
-                this,
-                [](const ElicitResult &result) {
-                    return QJsonValue(result.toJson());
-                });
+            return LLMQore::compat(m_elicitationProvider->elicit(req))
+                .then(this, [](const ElicitResult &result) { return QJsonValue(result.toJson()); });
         });
 }
 
 QFuture<InitializeResult> McpClient::connectAndInitialize(std::chrono::milliseconds timeout)
 {
     if (!m_transport) {
-        return makeErrorFuture(McpTransportError(QStringLiteral("No transport")))
+        return LLMQore::compat(makeErrorFuture(McpTransportError(QStringLiteral("No transport"))))
             .then(this, [](const QJsonValue &) { return InitializeResult{}; });
     }
 
@@ -254,41 +251,38 @@ QFuture<InitializeResult> McpClient::connectAndInitialize(std::chrono::milliseco
         {"clientInfo", m_clientInfo.toJson()},
     };
 
-    return m_session->sendRequest(QStringLiteral("initialize"), params, timeout)
-        .then(this,
-              [this](const QJsonValue &result) {
-                  m_initResult = InitializeResult::fromJson(result.toObject());
-                  m_initialized = true;
+    return LLMQore::compat(m_session->sendRequest(QStringLiteral("initialize"), params, timeout))
+        .then(this, [this](const QJsonValue &result) {
+            m_initResult = InitializeResult::fromJson(result.toObject());
+            m_initialized = true;
 
-                  const QString v = m_initResult.protocolVersion;
-                  bool known = false;
-                  for (const char *knownV : kKnownProtocolVersions) {
-                      if (v == QLatin1String(knownV)) {
-                          known = true;
-                          break;
-                      }
-                  }
-                  if (!known) {
-                      qCWarning(llmMcpLog).noquote()
-                          << QString("Unexpected protocol version from server: %1").arg(v);
-                  }
+            const QString v = m_initResult.protocolVersion;
+            bool known = false;
+            for (const char *knownV : kKnownProtocolVersions) {
+                if (v == QLatin1String(knownV)) {
+                    known = true;
+                    break;
+                }
+            }
+            if (!known) {
+                qCWarning(llmMcpLog).noquote()
+                    << QString("Unexpected protocol version from server: %1").arg(v);
+            }
 
-                  m_session->sendNotification(QStringLiteral("notifications/initialized"));
-                  emit initialized(m_initResult);
-                  return m_initResult;
-              })
-        .onFailed(this,
-                  [this](const McpException &e) -> InitializeResult {
-                      emit errorOccurred(e.message());
-                      e.raise();
-                      Q_UNREACHABLE_RETURN(InitializeResult{});
-                  })
-        .onFailed(this,
-                  [this](const std::exception &e) -> InitializeResult {
-                      const QString msg = QString::fromUtf8(e.what());
-                      emit errorOccurred(msg);
-                      throw McpException(msg);
-                  });
+            m_session->sendNotification(QStringLiteral("notifications/initialized"));
+            emit initialized(m_initResult);
+            return m_initResult;
+        })
+        .onFailed(this, [this](const auto &e) -> InitializeResult {
+            if constexpr (std::is_same_v<std::decay_t<decltype(e)>, McpException>) {
+                emit errorOccurred(e.message());
+                throw McpException(e.message());
+            } else {
+                const QString msg = QString::fromUtf8(e.what());
+                emit errorOccurred(msg);
+                throw McpException(msg);
+            }
+        });
 }
 
 QFuture<QJsonValue> McpClient::sendInitialized(
@@ -304,19 +298,19 @@ QFuture<void> McpClient::ping(std::chrono::milliseconds timeout)
     QFuture<QJsonValue> raw = (!m_transport || !m_transport->isOpen())
         ? makeErrorFuture(McpTransportError(QStringLiteral("Transport is not open")))
         : m_session->sendRequest(QStringLiteral("ping"), QJsonObject{}, timeout);
-    return raw.then(this, [](const QJsonValue &) {});
+    return LLMQore::compat(raw).then(this, [](const QJsonValue &) {});
 }
 
 QFuture<void> McpClient::setLogLevel(const QString &level)
 {
-    return sendInitialized(
-               QStringLiteral("logging/setLevel"), QJsonObject{{"level", level}})
+    return LLMQore::compat(
+               sendInitialized(QStringLiteral("logging/setLevel"), QJsonObject{{"level", level}}))
         .then(this, [](const QJsonValue &) {});
 }
 
 QFuture<QList<ToolInfo>> McpClient::listTools()
 {
-    return sendInitialized(QStringLiteral("tools/list"))
+    return LLMQore::compat(sendInitialized(QStringLiteral("tools/list")))
         .then(this, [this](const QJsonValue &result) {
             QList<ToolInfo> tools;
             const QJsonArray arr = result.toObject().value("tools").toArray();
@@ -330,9 +324,8 @@ QFuture<QList<ToolInfo>> McpClient::listTools()
 QFuture<LLMQore::ToolResult> McpClient::callTool(
     const QString &name, const QJsonObject &arguments)
 {
-    return sendInitialized(
-               QStringLiteral("tools/call"),
-               QJsonObject{{"name", name}, {"arguments", arguments}})
+    return LLMQore::compat(
+               sendInitialized(QStringLiteral("tools/call"), QJsonObject{{"name", name}, {"arguments", arguments}}))
         .then(this, [](const QJsonValue &result) {
             return LLMQore::ToolResult::fromJson(result.toObject());
         });
@@ -367,9 +360,10 @@ McpClient::CancellableToolCall McpClient::callToolWithProgress(
             });
     }
 
-    out.future = cancellable.future.then(this, [](const QJsonValue &result) {
-        return LLMQore::ToolResult::fromJson(result.toObject());
-    });
+    out.future = LLMQore::compat(cancellable.future)
+                     .then(this, [](const QJsonValue &result) {
+                         return LLMQore::ToolResult::fromJson(result.toObject());
+                     });
     return out;
 }
 
@@ -381,7 +375,7 @@ void McpClient::cancel(const QString &requestId, const QString &reason)
 
 QFuture<QList<ResourceInfo>> McpClient::listResources()
 {
-    return sendInitialized(QStringLiteral("resources/list"))
+    return LLMQore::compat(sendInitialized(QStringLiteral("resources/list")))
         .then(this, [](const QJsonValue &result) {
             QList<ResourceInfo> resources;
             const QJsonArray arr = result.toObject().value("resources").toArray();
@@ -393,7 +387,7 @@ QFuture<QList<ResourceInfo>> McpClient::listResources()
 
 QFuture<QList<ResourceTemplate>> McpClient::listResourceTemplates()
 {
-    return sendInitialized(QStringLiteral("resources/templates/list"))
+    return LLMQore::compat(sendInitialized(QStringLiteral("resources/templates/list")))
         .then(this, [](const QJsonValue &result) {
             QList<ResourceTemplate> templates;
             const QJsonArray arr = result.toObject().value("resourceTemplates").toArray();
@@ -405,7 +399,7 @@ QFuture<QList<ResourceTemplate>> McpClient::listResourceTemplates()
 
 QFuture<ResourceContents> McpClient::readResource(const QString &uri)
 {
-    return sendInitialized(QStringLiteral("resources/read"), QJsonObject{{"uri", uri}})
+    return LLMQore::compat(sendInitialized(QStringLiteral("resources/read"), QJsonObject{{"uri", uri}}))
         .then(this, [](const QJsonValue &result) {
             const QJsonObject obj = result.toObject();
             const QJsonArray contents = obj.value("contents").toArray();
@@ -417,19 +411,19 @@ QFuture<ResourceContents> McpClient::readResource(const QString &uri)
 
 QFuture<void> McpClient::subscribeResource(const QString &uri)
 {
-    return sendInitialized(QStringLiteral("resources/subscribe"), QJsonObject{{"uri", uri}})
+    return LLMQore::compat(sendInitialized(QStringLiteral("resources/subscribe"), QJsonObject{{"uri", uri}}))
         .then(this, [](const QJsonValue &) {});
 }
 
 QFuture<void> McpClient::unsubscribeResource(const QString &uri)
 {
-    return sendInitialized(QStringLiteral("resources/unsubscribe"), QJsonObject{{"uri", uri}})
+    return LLMQore::compat(sendInitialized(QStringLiteral("resources/unsubscribe"), QJsonObject{{"uri", uri}}))
         .then(this, [](const QJsonValue &) {});
 }
 
 QFuture<QList<PromptInfo>> McpClient::listPrompts()
 {
-    return sendInitialized(QStringLiteral("prompts/list"))
+    return LLMQore::compat(sendInitialized(QStringLiteral("prompts/list")))
         .then(this, [](const QJsonValue &result) {
             QList<PromptInfo> prompts;
             const QJsonArray arr = result.toObject().value("prompts").toArray();
@@ -446,10 +440,8 @@ QFuture<PromptGetResult> McpClient::getPrompt(
     if (!arguments.isEmpty())
         params.insert("arguments", arguments);
 
-    return sendInitialized(QStringLiteral("prompts/get"), params)
-        .then(this, [](const QJsonValue &result) {
-            return PromptGetResult::fromJson(result.toObject());
-        });
+    return LLMQore::compat(sendInitialized(QStringLiteral("prompts/get"), params))
+        .then(this, [](const QJsonValue &result) { return PromptGetResult::fromJson(result.toObject()); });
 }
 
 QFuture<CompletionResult> McpClient::complete(
@@ -465,10 +457,8 @@ QFuture<CompletionResult> McpClient::complete(
     if (!contextArguments.isEmpty())
         params.insert("context", QJsonObject{{"arguments", contextArguments}});
 
-    return sendInitialized(QStringLiteral("completion/complete"), params)
-        .then(this, [](const QJsonValue &result) {
-            return CompletionResult::fromJson(result.toObject());
-        });
+    return LLMQore::compat(sendInitialized(QStringLiteral("completion/complete"), params))
+        .then(this, [](const QJsonValue &result) { return CompletionResult::fromJson(result.toObject()); });
 }
 
 void McpClient::setSamplingClient(

--- a/source/mcp/McpHttpTransport.cpp
+++ b/source/mcp/McpHttpTransport.cpp
@@ -10,6 +10,7 @@
 #include <LLMQore/Log.hpp>
 #include <LLMQore/SSEParser.hpp>
 
+#include <LLMQore/FutureUtils.hpp>
 #include <QByteArray>
 #include <QByteArrayList>
 #include <QJsonDocument>
@@ -128,11 +129,10 @@ struct McpHttpTransport::Impl
 
         const QByteArray body = QJsonDocument(message).toJson(QJsonDocument::Compact);
 
-        http->send(req, QByteArrayView("POST"), body)
+        (void)LLMQore::compat(http->send(req, QByteArrayView("POST"), body))
             .then(q, [this](const HttpResponse &response) {
                 if (!response.isSuccess()) {
-                    const QString reason
-                        = QString("POST failed (HTTP %1)").arg(response.statusCode);
+                    const QString reason = QString("POST failed (HTTP %1)").arg(response.statusCode);
                     qCWarning(llmMcpLog).noquote() << reason;
                     emit q->errorOccurred(reason);
                 }
@@ -161,7 +161,7 @@ struct McpHttpTransport::Impl
 
         const QByteArray body = QJsonDocument(message).toJson(QJsonDocument::Compact);
 
-        http->send(req, QByteArrayView("POST"), body)
+        (void)LLMQore::compat(http->send(req, QByteArrayView("POST"), body))
             .then(q, [this](const HttpResponse &response) { handleV2025Response(response); })
             .onFailed(q, [this](const HttpTransportError &e) {
                 const QString reason = QString("HTTP error: %1").arg(e.message());

--- a/source/mcp/McpRemoteTool.cpp
+++ b/source/mcp/McpRemoteTool.cpp
@@ -6,6 +6,7 @@
 #include <LLMQore/McpClient.hpp>
 #include <LLMQore/McpExceptions.hpp>
 
+#include <LLMQore/FutureUtils.hpp>
 #include <QPromise>
 
 namespace LLMQore::Mcp {
@@ -57,11 +58,11 @@ QFuture<LLMQore::ToolResult> McpRemoteTool::executeAsync(const QJsonObject &inpu
         return p.future();
     }
 
-    return m_client->callTool(m_info.name, input)
-        .onFailed(this, [](const McpException &e) {
-            return LLMQore::ToolResult::error(e.message());
-        })
-        .onFailed(this, [](const std::exception &e) {
+    return LLMQore::compat(m_client->callTool(m_info.name, input))
+        .then(this, [](const LLMQore::ToolResult &result) { return result; })
+        .onFailed(this, [](const auto &e) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(e)>, McpException>)
+                return LLMQore::ToolResult::error(e.message());
             return LLMQore::ToolResult::error(QString::fromUtf8(e.what()));
         });
 }

--- a/source/mcp/McpServer.cpp
+++ b/source/mcp/McpServer.cpp
@@ -12,9 +12,11 @@
 #include <LLMQore/McpTransport.hpp>
 #include <LLMQore/ToolResult.hpp>
 #include <LLMQore/ToolRegistry.hpp>
+#include <LLMQore/FutureUtils.hpp>
 
 #include <QFuture>
 #include <QJsonArray>
+#include <QFutureWatcher>
 #include <QPromise>
 
 #include <optional>
@@ -57,19 +59,38 @@ QFuture<QJsonValue> collectListFromProviders(
     if (futures.isEmpty())
         return makeReadyFuture(QJsonObject{{resultKey, QJsonArray{}}});
 
-    return QtFuture::whenAll(futures.begin(), futures.end())
-        .then(ctx, [resultKey](const QList<QFuture<QList<Item>>> &finished) {
-            QJsonArray merged;
-            for (const QFuture<QList<Item>> &f : finished) {
-                try {
-                    const QList<Item> list = f.result();
-                    for (const Item &item : list)
-                        merged.append(item.toJson());
-                } catch (...) {
-                }
-            }
-            return QJsonValue(QJsonObject{{resultKey, merged}});
-        });
+    struct State
+    {
+        std::shared_ptr<QPromise<QJsonValue>> promise;
+        QJsonArray merged;
+        int remaining = 0;
+    };
+
+    auto state = std::make_shared<State>();
+    state->promise = std::make_shared<QPromise<QJsonValue>>();
+    state->promise->start();
+    state->remaining = futures.size();
+
+    for (const QFuture<QList<Item>> &future : futures) {
+        auto *watcher = new QFutureWatcher<QList<Item>>(ctx);
+        QObject::connect(watcher, &QFutureWatcher<QList<Item>>::finished, watcher,
+                         [state, watcher, resultKey]() {
+                             try {
+                                 const QList<Item> list = watcher->future().result();
+                                 for (const Item &item : list)
+                                     state->merged.append(item.toJson());
+                             } catch (...) {
+                             }
+                             if (--state->remaining == 0) {
+                                 state->promise->addResult(QJsonValue(QJsonObject{{resultKey, state->merged}}));
+                                 state->promise->finish();
+                             }
+                             watcher->deleteLater();
+                         });
+        watcher->setFuture(future);
+    }
+
+    return state->promise->future();
 }
 
 template<typename Provider, typename T>
@@ -100,19 +121,16 @@ void tryEachAdvance(std::shared_ptr<TryEachState<Provider, T>> s)
     Provider *provider = s->providers.at(s->index).data();
     ++s->index;
 
-    s->runFn(provider)
-        .then(s->ctx,
-              [s](const T &value) {
-                  if (auto json = s->extract(value)) {
-                      s->promise->addResult(std::move(*json));
-                      s->promise->finish();
-                  } else {
-                      tryEachAdvance(s);
-                  }
-              })
-        .onFailed(s->ctx, [s](const std::exception &) {
-            tryEachAdvance(s);
-        });
+    (void)LLMQore::compat(s->runFn(provider))
+        .then(s->ctx, [s](const T &value) {
+            if (auto json = s->extract(value)) {
+                s->promise->addResult(std::move(*json));
+                s->promise->finish();
+            } else {
+                tryEachAdvance(s);
+            }
+        })
+        .onFailed(s->ctx, [s](const std::exception &) { tryEachAdvance(s); });
 }
 
 template<typename Provider, typename T, typename Run, typename Extract>
@@ -239,14 +257,12 @@ void McpServer::installHandlers()
                     ErrorCode::MethodNotFound, QString("Tool not found: %1").arg(name)));
             }
 
-            return tool->executeAsync(args)
-                .then(this,
-                      [](const LLMQore::ToolResult &result) {
-                          return QJsonValue(result.toJson());
-                      })
+            return LLMQore::compat(tool->executeAsync(args))
+                .then(this, [](const LLMQore::ToolResult &result) {
+                    return QJsonValue(result.toJson());
+                })
                 .onFailed(this, [](const std::exception &e) {
-                    return QJsonValue(
-                        LLMQore::ToolResult::error(QString::fromUtf8(e.what())).toJson());
+                    return QJsonValue(LLMQore::ToolResult::error(QString::fromUtf8(e.what())).toJson());
                 });
         });
 
@@ -368,23 +384,42 @@ void McpServer::installHandlers()
                 if (futures.isEmpty())
                     return makeReadyFuture(CompletionResult{}.toJson());
 
-                return QtFuture::whenAll(futures.begin(), futures.end())
-                    .then(this, [](const QList<QFuture<CompletionResult>> &finished) {
-                        CompletionResult merged;
-                        for (const QFuture<CompletionResult> &f : finished) {
-                            try {
-                                const CompletionResult r = f.result();
-                                for (const QString &v : r.values)
-                                    merged.values.append(v);
-                                if (r.hasMore)
-                                    merged.hasMore = true;
-                                if (r.total.has_value())
-                                    merged.total = merged.total.value_or(0) + *r.total;
-                            } catch (...) {
-                            }
-                        }
-                        return QJsonValue(merged.toJson());
-                    });
+                struct State
+                {
+                    std::shared_ptr<QPromise<QJsonValue>> promise;
+                    CompletionResult merged;
+                    int remaining = 0;
+                };
+
+                auto state = std::make_shared<State>();
+                state->promise = std::make_shared<QPromise<QJsonValue>>();
+                state->promise->start();
+                state->remaining = futures.size();
+
+                for (const QFuture<CompletionResult> &future : futures) {
+                    auto *watcher = new QFutureWatcher<CompletionResult>(this);
+                    QObject::connect(watcher, &QFutureWatcher<CompletionResult>::finished, watcher,
+                                     [state, watcher]() {
+                                         try {
+                                             const CompletionResult r = watcher->future().result();
+                                             for (const QString &v : r.values)
+                                                 state->merged.values.append(v);
+                                             if (r.hasMore)
+                                                 state->merged.hasMore = true;
+                                             if (r.total.has_value())
+                                                 state->merged.total = state->merged.total.value_or(0) + *r.total;
+                                         } catch (...) {
+                                         }
+                                         if (--state->remaining == 0) {
+                                             state->promise->addResult(QJsonValue(state->merged.toJson()));
+                                             state->promise->finish();
+                                         }
+                                         watcher->deleteLater();
+                                     });
+                    watcher->setFuture(future);
+                }
+
+                return state->promise->future();
             };
 
             if (ref.type == QLatin1String("ref/prompt")) {
@@ -513,11 +548,9 @@ QFuture<CreateMessageResult> McpServer::createSamplingMessage(
         return p.future();
     }
 
-    return m_session
-        ->sendRequest(QStringLiteral("sampling/createMessage"), params.toJson(), timeout)
-        .then(this, [](const QJsonValue &value) {
-            return CreateMessageResult::fromJson(value.toObject());
-        });
+    return LLMQore::compat(
+               m_session->sendRequest(QStringLiteral("sampling/createMessage"), params.toJson(), timeout))
+        .then(this, [](const QJsonValue &value) { return CreateMessageResult::fromJson(value.toObject()); });
 }
 
 QFuture<ElicitResult> McpServer::createElicitation(
@@ -540,11 +573,9 @@ QFuture<ElicitResult> McpServer::createElicitation(
         return p.future();
     }
 
-    return m_session
-        ->sendRequest(QStringLiteral("elicitation/create"), params.toJson(), timeout)
-        .then(this, [](const QJsonValue &value) {
-            return ElicitResult::fromJson(value.toObject());
-        });
+    return LLMQore::compat(
+               m_session->sendRequest(QStringLiteral("elicitation/create"), params.toJson(), timeout))
+        .then(this, [](const QJsonValue &value) { return ElicitResult::fromJson(value.toObject()); });
 }
 
 void McpServer::sendLogMessage(

--- a/source/tools/ToolHandler.cpp
+++ b/source/tools/ToolHandler.cpp
@@ -4,6 +4,7 @@
 #include "ToolHandler.hpp"
 #include <LLMQore/ToolExceptions.hpp>
 
+#include <QFutureInterface>
 #include <QThread>
 #include <QtConcurrent>
 
@@ -32,7 +33,8 @@ QFuture<ToolResult> ToolHandler::executeToolAsync(
         QTimer::singleShot(0, this, [this, requestId, toolId]() {
             emit toolFailed(requestId, toolId, QStringLiteral("Tool is null"));
         });
-        return QFuture<ToolResult>();
+        QFutureInterface<ToolResult> promise;
+        return promise.future();
     }
 
     auto *execution = new ToolExecution();

--- a/source/tools/ToolHandler.cpp
+++ b/source/tools/ToolHandler.cpp
@@ -6,7 +6,7 @@
 
 #include <QFutureInterface>
 #include <QThread>
-#include <QtConcurrent>
+#include <QTimer>
 
 #include <LLMQore/Log.hpp>
 

--- a/source/tools/ToolResult.cpp
+++ b/source/tools/ToolResult.cpp
@@ -14,6 +14,7 @@ const int _toolResultMetaType = []() {
     qRegisterMetaType<LLMQore::ToolContent>("LLMQore::ToolContent");
     qRegisterMetaType<LLMQore::ToolResult>("LLMQore::ToolResult");
     qRegisterMetaType<LLMQoreToolResultHash>("LLMQoreToolResultHash");
+    qRegisterMetaType<LLMQoreToolResultHash>("QHash<QString,ToolResult>");
     return 0;
 }();
 } // namespace

--- a/source/tools/ToolsManager.cpp
+++ b/source/tools/ToolsManager.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "ToolHandler.hpp"
+#include <LLMQore/FutureUtils.hpp>
 #include <LLMQore/Log.hpp>
 #include <LLMQore/McpClient.hpp>
 #include <LLMQore/McpHttpTransport.hpp>
@@ -110,13 +111,13 @@ void ToolsManager::addMcpServer(const McpServerEntry &entry)
     auto *client = new Mcp::McpClient(
         transport, Mcp::Implementation{entry.name, QStringLiteral(LLMQORE_VERSION_STRING)}, this);
 
-    client->connectAndInitialize().then(this, [this, client](const Mcp::InitializeResult &) {
-        addMcpClient(client);
-    }).onFailed(this, [entry](const std::exception &e) {
-        qCWarning(llmToolsLog).noquote()
-            << QString("Failed to connect MCP server '%1': %2")
-                   .arg(entry.name, QString::fromUtf8(e.what()));
-    });
+    (void)LLMQore::compat(client->connectAndInitialize())
+        .then(this, [this, client](const Mcp::InitializeResult &) { addMcpClient(client); })
+        .onFailed(this, [entry](const std::exception &e) {
+            qCWarning(llmToolsLog).noquote()
+                << QString("Failed to connect MCP server '%1': %2")
+                       .arg(entry.name, QString::fromUtf8(e.what()));
+        });
 }
 
 void ToolsManager::loadMcpServers(const QJsonObject &config)
@@ -177,28 +178,29 @@ void ToolsManager::removeMcpClient(Mcp::McpClient *client)
 
 void ToolsManager::registerMcpTools(Mcp::McpClient *client)
 {
-    client->listTools().then(this, [this, client](const QList<Mcp::ToolInfo> &tools) {
-        QSet<QString> incoming;
-        incoming.reserve(tools.size());
-        for (const Mcp::ToolInfo &t : tools)
-            incoming.insert(t.name);
+    (void)LLMQore::compat(client->listTools())
+        .then(this, [this, client](const QList<Mcp::ToolInfo> &tools) {
+            QSet<QString> incoming;
+            incoming.reserve(tools.size());
+            for (const Mcp::ToolInfo &t : tools)
+                incoming.insert(t.name);
 
-        const QStringList previous = m_mcpClientTools.value(client);
-        for (const QString &old : previous) {
-            if (!incoming.contains(old))
-                removeTool(old);
-        }
+            const QStringList previous = m_mcpClientTools.value(client);
+            for (const QString &old : previous) {
+                if (!incoming.contains(old))
+                    removeTool(old);
+            }
 
-        QStringList registered;
-        registered.reserve(tools.size());
-        for (const Mcp::ToolInfo &info : tools) {
-            if (m_tools.contains(info.name))
-                removeTool(info.name);
-            addTool(new Mcp::McpRemoteTool(client, info));
-            registered.append(info.name);
-        }
-        m_mcpClientTools[client] = std::move(registered);
-    });
+            QStringList registered;
+            registered.reserve(tools.size());
+            for (const Mcp::ToolInfo &info : tools) {
+                if (m_tools.contains(info.name))
+                    removeTool(info.name);
+                addTool(new Mcp::McpRemoteTool(client, info));
+                registered.append(info.name);
+            }
+            m_mcpClientTools[client] = std::move(registered);
+        });
 }
 
 QString ToolsManager::displayName(const QString &toolName) const

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,9 +39,13 @@ add_executable(LLMQoreUnitTests
 
 set_target_properties(LLMQoreUnitTests PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
 )
+
+if(QT_VERSION_MAJOR EQUAL 5)
+    set_property(TARGET LLMQoreUnitTests PROPERTY CXX_STANDARD 17)
+endif()
 
 target_include_directories(LLMQoreUnitTests PRIVATE
     ${PROJECT_SOURCE_DIR}/source

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(Qt6 REQUIRED COMPONENTS Test Concurrent)
+if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Test Concurrent)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test Concurrent)
 
 include(FetchContent)
 
@@ -46,8 +49,8 @@ target_include_directories(LLMQoreUnitTests PRIVATE
 
 target_link_libraries(LLMQoreUnitTests PRIVATE
     LLMQore::LLMQore
-    Qt6::Test
-    Qt6::Concurrent
+    Qt${QT_VERSION_MAJOR}::Test
+    Qt${QT_VERSION_MAJOR}::Concurrent
     GTest::gtest
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ add_executable(LLMQoreUnitTests
 
 set_target_properties(LLMQoreUnitTests PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD 20
+    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED ON
 )
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -17,9 +17,13 @@ add_executable(LLMQoreIntegrationTests
 
 set_target_properties(LLMQoreIntegrationTests PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
 )
+
+if(QT_VERSION_MAJOR EQUAL 5)
+    set_property(TARGET LLMQoreIntegrationTests PROPERTY CXX_STANDARD 17)
+endif()
 
 target_include_directories(LLMQoreIntegrationTests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(LLMQoreIntegrationTests
 
 set_target_properties(LLMQoreIntegrationTests PROPERTIES
     AUTOMOC ON
-    CXX_STANDARD 20
+    CXX_STANDARD ${LLMQORE_CXX_STANDARD}
     CXX_STANDARD_REQUIRED ON
 )
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(Qt6 REQUIRED COMPONENTS Test Concurrent)
+if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Test Concurrent)
+endif()
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test Concurrent)
 
 add_executable(LLMQoreIntegrationTests
     IntegrationTestTools.cpp
@@ -24,8 +27,8 @@ target_include_directories(LLMQoreIntegrationTests PRIVATE
 
 target_link_libraries(LLMQoreIntegrationTests PRIVATE
     LLMQore::LLMQore
-    Qt6::Test
-    Qt6::Concurrent
+    Qt${QT_VERSION_MAJOR}::Test
+    Qt${QT_VERSION_MAJOR}::Concurrent
     GTest::gtest_main
 )
 

--- a/tests/tst_McpTypes.cpp
+++ b/tests/tst_McpTypes.cpp
@@ -213,7 +213,9 @@ TEST(McpTypesTest, CompletionTypesRoundTrip)
     EXPECT_EQ(argBack.value, arg.value);
 
     CompletionResult res;
-    res.values = {"python", "pyramid", "pytorch"};
+    res.values = QStringList{QStringLiteral("python"),
+                             QStringLiteral("pyramid"),
+                             QStringLiteral("pytorch")};
     res.total = 10;
     res.hasMore = true;
     const QJsonObject resObj = res.toJson();
@@ -285,7 +287,7 @@ TEST(McpTypesTest, SamplingMessageAndParamsRoundTrip)
     params.includeContext = "thisServer";
     params.temperature = 0.1;
     params.maxTokens = 128;
-    params.stopSequences = {"END", "###"};
+    params.stopSequences = QStringList{QStringLiteral("END"), QStringLiteral("###")};
     params.metadata = QJsonObject{{"source", "unit-test"}};
 
     const QJsonObject obj = params.toJson();
@@ -305,7 +307,8 @@ TEST(McpTypesTest, SamplingMessageAndParamsRoundTrip)
     ASSERT_TRUE(back.temperature.has_value());
     EXPECT_DOUBLE_EQ(*back.temperature, 0.1);
     EXPECT_EQ(back.maxTokens, 128);
-    EXPECT_EQ(back.stopSequences, QStringList({"END", "###"}));
+    EXPECT_EQ(back.stopSequences,
+              (QStringList{QStringLiteral("END"), QStringLiteral("###")}));
     ASSERT_TRUE(back.modelPreferences.has_value());
     ASSERT_EQ(back.modelPreferences->hints.size(), 1);
     EXPECT_EQ(back.modelPreferences->hints.first().name, "claude-sonnet");

--- a/tests/tst_ToolHandler.cpp
+++ b/tests/tst_ToolHandler.cpp
@@ -225,7 +225,7 @@ TEST_F(ToolHandlerTest, ExecuteNullTool)
 
     // Null tool should not crash and should emit toolFailed asynchronously.
     auto future = handler.executeToolAsync("req-1", "tool-1", nullptr, {});
-    EXPECT_FALSE(future.isValid());
+    EXPECT_FALSE(future.isStarted());
 
     EXPECT_TRUE(failedSpy.wait(3000));
     EXPECT_EQ(failedSpy.count(), 1);


### PR DESCRIPTION
## Description
  This PR adds Qt 5 compatibility to llmqore without dropping Qt 6 support.

 ### What changed

  - Added Qt-version-aware compatibility shims for missing Qt 6 APIs in Qt 5 builds.
  - Kept the public C++ API and async flow largely unchanged by centralizing the compatibility layer.
  - Updated CMake to link against `Qt${QT_VERSION_MAJOR}::...` so the project builds against both Qt 5 and Qt 6.
  - Restored/install-adjusted the Qt 5 compatibility headers so downstream consumers can build against installed packages.
  - Updated the MCP bridge and example targets to work in both Qt 5 and Qt 6 with minimal source changes.
  - Adjusted tests and integration CMake files to follow the same version-aware Qt linking.

  ### Validation

  - Built successfully with Qt 5 and Qt6 in separate build trees
  - Successfully executed the unit test suite

  ### Notes

  - The bridge and example targets remain available across both Qt versions.
  - `example-chat` stays Qt 6-only because it depends on `qt_add_qml_module`.

Closes #20 