### PR TITLE
fix: wrap Qt forward declarations in QT_FORWARD_DECLARE_CLASS

### DIFF
--- a/include/LLMQore/HttpClient.hpp
+++ b/include/LLMQore/HttpClient.hpp
@@ -17,8 +17,8 @@
 #include <LLMQore/HttpTransportError.hpp>
 #include <LLMQore/LLMQore_global.h>
 
-class QNetworkProxy;
-class QNetworkRequest;
+QT_FORWARD_DECLARE_CLASS(QNetworkProxy)
+QT_FORWARD_DECLARE_CLASS(QNetworkRequest)
 
 namespace LLMQore {
 

--- a/include/LLMQore/HttpStream.hpp
+++ b/include/LLMQore/HttpStream.hpp
@@ -16,7 +16,7 @@
 #include <LLMQore/HttpTransportError.hpp>
 #include <LLMQore/LLMQore_global.h>
 
-class QNetworkReply;
+QT_FORWARD_DECLARE_CLASS(QNetworkReply)
 
 namespace LLMQore {
 

--- a/include/LLMQore/HttpTransport.hpp
+++ b/include/LLMQore/HttpTransport.hpp
@@ -14,7 +14,7 @@
 #include <LLMQore/HttpTransportError.hpp>
 #include <LLMQore/LLMQore_global.h>
 
-class QNetworkRequest;
+QT_FORWARD_DECLARE_CLASS(QNetworkRequest)
 
 namespace LLMQore {
 

--- a/include/LLMQore/JsonRpcSession.hpp
+++ b/include/LLMQore/JsonRpcSession.hpp
@@ -21,7 +21,7 @@
 #include <LLMQore/LLMQore_global.h>
 #include <LLMQore/RpcTransport.hpp>
 
-class QTimer;
+QT_FORWARD_DECLARE_CLASS(QTimer)
 
 namespace LLMQore::Rpc {
 

--- a/include/LLMQore/McpStdioServerTransport.hpp
+++ b/include/LLMQore/McpStdioServerTransport.hpp
@@ -8,7 +8,7 @@
 #include <LLMQore/LLMQore_global.h>
 #include <LLMQore/RpcTransport.hpp>
 
-class QIODevice;
+QT_FORWARD_DECLARE_CLASS(QIODevice)
 
 namespace LLMQore::Mcp {
 

--- a/include/LLMQore/ProtocolPeer.hpp
+++ b/include/LLMQore/ProtocolPeer.hpp
@@ -21,7 +21,7 @@
 #include <LLMQore/RpcExceptions.hpp>
 #include <LLMQore/RpcTransport.hpp>
 
-class QLoggingCategory;
+QT_FORWARD_DECLARE_CLASS(QLoggingCategory)
 
 namespace LLMQore::Rpc {
 


### PR DESCRIPTION
Bare forward declarations like 

`class QNetworkRequest;`

put the class in the global namespace. If Qt was built with -qtnamespace, the real class is in the Qt namespace instead and the name becomes ambiguous, so the library doesn't compile.

On a normal Qt build, the macro `QT_FORWARD_DECLARE_CLASS` expands to the bare declaration, so nothing changes for anyone else.

I ran into this embedding LLMQore in an app that ships a namespaced Qt 6.8.8. Library, tests and examples all build against it once fixed and the unit tests pass.